### PR TITLE
BusinessProcessor.GetStatisticsAsync() - fixed possible null value fo…

### DIFF
--- a/src/InstagramApiSharp/Classes/ResponseWrappers/Business/InstaStatisticsResponse.cs
+++ b/src/InstagramApiSharp/Classes/ResponseWrappers/Business/InstaStatisticsResponse.cs
@@ -284,7 +284,7 @@ namespace InstagramApiSharp.Classes.ResponseWrappers.Business
         [JsonProperty("followers_unit_state")]
         public string FollowersUnitState { get; set; }
         [JsonProperty("followers_delta_from_last_week")]
-        public int FollowersDeltaFromLastWeek { get; set; }
+        public int? FollowersDeltaFromLastWeek { get; set; } = 0;
         [JsonProperty("gender_graph")]
         public InstaStatisticsDataPointsResponse GenderGraph { get; set; }
         [JsonProperty("all_followers_age_graph")]

--- a/src/InstagramApiSharp/Converters/Business/InstaStatisticsConverter.cs
+++ b/src/InstagramApiSharp/Converters/Business/InstaStatisticsConverter.cs
@@ -123,7 +123,7 @@ namespace InstagramApiSharp.Converters.Business
                     statisfics.BusinessManager.FollowersUnit = new InstaStatisticsFollowersUnit
                     {
                         FollowersUnitState = businessManager.FollowersUnit.FollowersUnitState,
-                        FollowersDeltaFromLastWeek = businessManager.FollowersUnit.FollowersDeltaFromLastWeek
+                        FollowersDeltaFromLastWeek = businessManager.FollowersUnit.FollowersDeltaFromLastWeek ?? default(int)
                     };
                     foreach (var dataPoint in businessManager.FollowersUnit.AllFollowersAgeGraph.DataPoints)
                     {


### PR DESCRIPTION
Hello! 
I transferred my account to business just now
After call BusinessProcessor.GetStatisticsAsync() have exception
```
{"Error converting value {null} to type 'System.Int32'. Path 'data.user.business_manager.followers_unit.followers_delta_from_last_week', line 1, position 1777."}
```
json data
```json
{"followers_unit":{"followers_unit_state":"NOT_ENOUGH_DATA","followers_delta_from_last_week":null,"gender_graph":null,"all_followers_age_graph":null,"men_followers_age_graph":null,"women_followers_age_graph":null,"followers_top_cities_graph":null,"followers_top_countries_graph":null,"week_daily_followers_graph":null,"days_hourly_followers_graphs":[]}}
```
To fix it, changed the FollowersDeltaFromLastWeek type to nullable