### PR TITLE
InstaDirectInboxThread - add field LastPermanentItem

### DIFF
--- a/src/InstagramApiSharp/Classes/Models/Direct/InstaDirectInboxThread.cs
+++ b/src/InstagramApiSharp/Classes/Models/Direct/InstaDirectInboxThread.cs
@@ -39,6 +39,8 @@ namespace InstagramApiSharp.Classes.Models
 
         public List<InstaDirectInboxItem> Items { get; set; }
         
+        public InstaDirectInboxItem LastPermanentItem { get; set; }
+
         public bool IsPin { get; set; }
 
         public bool ValuedRequest { get; set; }

--- a/src/InstagramApiSharp/Classes/ResponseWrappers/Direct/InstaDirectInboxThreadResponse.cs
+++ b/src/InstagramApiSharp/Classes/ResponseWrappers/Direct/InstaDirectInboxThreadResponse.cs
@@ -39,6 +39,7 @@ namespace InstagramApiSharp.Classes.ResponseWrappers
 
         [JsonProperty("items")] public List<InstaDirectInboxItemResponse> Items { get; set; }
 
+        [JsonProperty("last_permanent_item")] public InstaDirectInboxItemResponse LastPermanentItem { get; set; }
 
         [JsonProperty("mentions_muted")] public bool? MentionsMuted { get; set; }
 

--- a/src/InstagramApiSharp/Converters/Directs/InstaDirectThreadConverter.cs
+++ b/src/InstagramApiSharp/Converters/Directs/InstaDirectThreadConverter.cs
@@ -37,6 +37,7 @@ namespace InstagramApiSharp.Converters
                 NewestCursor = SourceObject.NewestCursor,
                 ThreadType = SourceObject.ThreadType,
                 Title = SourceObject.Title,
+            
                 MentionsMuted = SourceObject.MentionsMuted ?? false
             };
 
@@ -56,6 +57,11 @@ namespace InstagramApiSharp.Converters
                 }
             }
 
+            if (SourceObject.LastPermanentItem != null)
+            {
+                var converter = ConvertersFabric.Instance.GetDirectThreadItemConverter(SourceObject.LastPermanentItem);
+                thread.LastPermanentItem = converter.Convert();
+            }
             if (SourceObject.Users != null && SourceObject.Users.Count > 0)
             {
                 foreach (var user in SourceObject.Users)


### PR DESCRIPTION
Hello! During the work with Inbox. In some dialogs (with 1 item) have Items property with null/empty value.
After some reseach i'm found message in last_permanent_Item json property. Added it to model.
Regards