### PR TITLE
Added additional error handlers

### DIFF
--- a/src/InstagramApiSharp/API/Processors/HelperProcessor.cs
+++ b/src/InstagramApiSharp/API/Processors/HelperProcessor.cs
@@ -959,7 +959,16 @@ namespace InstagramApiSharp.API.Processors
                 request.Headers.Add("retry_context", retryContext);
                 var response = await _httpRequestProcessor.SendAsync(request);
                 var json = await response.Content.ReadAsStringAsync();
-                
+
+                JObject rootJsonObj = JObject.Parse(json);
+                var status = rootJsonObj["status"];
+
+                if (status != null && status.ToString() == "fail")
+                {
+                    var message = rootJsonObj["message"].ToString();
+                    return Result.Fail<InstaMedia>(message);
+                }
+
                 var mediaResponse =
                      JsonConvert.DeserializeObject<InstaMediaItemResponse>(json, new InstaMediaDataConverter());
                 var converter = ConvertersFabric.Instance.GetSingleMediaConverter(mediaResponse);

--- a/src/InstagramApiSharp/Helpers/ErrorHandlingHelper.cs
+++ b/src/InstagramApiSharp/Helpers/ErrorHandlingHelper.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using InstagramApiSharp.Classes.ResponseWrappers;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace InstagramApiSharp.Helpers
 {
@@ -13,6 +14,16 @@ namespace InstagramApiSharp.Helpers
             {
                 if (json.Contains("Oops, an error occurred"))
                     badStatus.Message = json;
+                else if (json.Contains("debug_info"))
+                {
+                    JObject root = JObject.Parse(json);
+                    JToken debugInfo = root["debug_info"];
+                    string type = debugInfo["type"].ToString();
+                    string message = debugInfo["message"].ToString();
+
+                    badStatus = new BadStatusResponse() { Message = message, ErrorType = type };
+                }
+
                 else badStatus = JsonConvert.DeserializeObject<BadStatusResponse>(json);
             }
             catch (Exception ex)


### PR DESCRIPTION
I've encountered some errors which are not handled.

So I added some additional error handlers for those. Now it's throwing a meaningful exception instead of a dumb NullReferenceException.