### PR TITLE
Update GetCurrentUserAsync's HTTP method from POST to GET

### DIFF
--- a/src/InstagramApiSharp/API/Processors/UserProcessor.cs
+++ b/src/InstagramApiSharp/API/Processors/UserProcessor.cs
@@ -239,14 +239,7 @@ namespace InstagramApiSharp.API.Processors
             try
             {
                 var instaUri = UriCreator.GetCurrentUserUri();
-                var fields = new Dictionary<string, string>
-                {
-                    {"_uuid", _deviceInfo.DeviceGuid.ToString()},
-                    {"_uid", _user.LoggedInUser.Pk.ToString()},
-                    {"_csrftoken", _user.CsrfToken}
-                };
-                var request = _httpHelper.GetDefaultRequest(HttpMethod.Post, instaUri, _deviceInfo);
-                request.Content = new FormUrlEncodedContent(fields);
+                var request = _httpHelper.GetDefaultRequest(HttpMethod.Get, instaUri, _deviceInfo);
                 var response = await _httpRequestProcessor.SendAsync(request);
                 var json = await response.Content.ReadAsStringAsync();
 


### PR DESCRIPTION
According to Instagram's document [https://instagram.api-docs.io/1.0/accounts](https://instagram.api-docs.io/1.0/accounts), the /api/v1/accounts/current_user  function is GET HTTP verb, not POST. 

So I update the HTTP verb from POST to GET for this GetCurrentUserAsync() function.