### PR TITLE
Add checkpoint_required error

### DIFF
--- a/src/InstagramApiSharp/Classes/Result.cs
+++ b/src/InstagramApiSharp/Classes/Result.cs
@@ -150,6 +150,9 @@ namespace InstagramApiSharp.Classes
             if (!status.IsOk() && status.Message.Contains("wait a few minutes"))
                 responseType = ResponseType.RequestsLimit;
 
+            if (!string.IsNullOrEmpty(status.Message) && status.Message.Contains("checkpoint_required"))
+                responseType = ResponseType.CheckPointRequired;
+
             if (!string.IsNullOrEmpty(status.Message) && status.Message.Contains("consent_required"))
                 responseType = ResponseType.ConsentRequired;
 


### PR DESCRIPTION
Adds the `checkpoint_required` error that instagram has been sending lately. I did not look into what it means, but I assume that it is a new anti-bot measure.
