### PR TITLE
Fix issue with auto_expand_chaining null

### DIFF
--- a/src/InstagramApiSharp/Classes/Models/User/InstaUserInfo.cs
+++ b/src/InstagramApiSharp/Classes/Models/User/InstaUserInfo.cs
@@ -102,7 +102,7 @@ namespace InstagramApiSharp.Classes.Models
 
         public bool HasUnseenBestiesMedia { get; set; }
 
-        public bool AutoExpandChaining { get; set; }
+        public bool? AutoExpandChaining { get; set; }
 
         public InstaBiographyEntities BiographyWithEntities { get; set; }
 

--- a/src/InstagramApiSharp/Classes/ResponseWrappers/User/InstaUserInfoResponse.cs
+++ b/src/InstagramApiSharp/Classes/ResponseWrappers/User/InstaUserInfoResponse.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.ComponentModel;
 using InstagramApiSharp.Classes.Models;
 using Newtonsoft.Json;
 

--- a/src/InstagramApiSharp/Classes/ResponseWrappers/User/InstaUserInfoResponse.cs
+++ b/src/InstagramApiSharp/Classes/ResponseWrappers/User/InstaUserInfoResponse.cs
@@ -105,9 +105,8 @@ namespace InstagramApiSharp.Classes.ResponseWrappers
 
         [JsonProperty("has_unseen_besties_media")] public bool HasUnseenBestiesMedia { get; set; }
 
-        [JsonProperty("auto_expand_chaining", DefaultValueHandling = DefaultValueHandling.Populate, NullValueHandling = NullValueHandling.Ignore)]
-        [DefaultValue(false)]
-        public bool AutoExpandChaining { get; set; }
+        [JsonProperty("auto_expand_chaining", NullValueHandling = NullValueHandling.Include)]
+        public bool? AutoExpandChaining { get; set; }
         
         [JsonProperty("biography_with_entities")] public InstaBiographyEntities BiographyWithEntities { get; set; }
 

--- a/src/InstagramApiSharp/Classes/ResponseWrappers/User/InstaUserInfoResponse.cs
+++ b/src/InstagramApiSharp/Classes/ResponseWrappers/User/InstaUserInfoResponse.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.ComponentModel;
 using InstagramApiSharp.Classes.Models;
 using Newtonsoft.Json;
 
@@ -104,8 +105,9 @@ namespace InstagramApiSharp.Classes.ResponseWrappers
 
         [JsonProperty("has_unseen_besties_media")] public bool HasUnseenBestiesMedia { get; set; }
 
-        [JsonProperty("auto_expand_chaining")] public bool AutoExpandChaining { get; set; }
-
+        [JsonProperty("auto_expand_chaining", DefaultValueHandling = DefaultValueHandling.Populate, NullValueHandling = NullValueHandling.Ignore)]
+        [DefaultValue(false)]
+        public bool AutoExpandChaining { get; set; }
         
         [JsonProperty("biography_with_entities")] public InstaBiographyEntities BiographyWithEntities { get; set; }
 

--- a/src/InstagramApiSharp/InstagramApiSharp.csproj
+++ b/src/InstagramApiSharp/InstagramApiSharp.csproj
@@ -292,8 +292,8 @@ v1.3.3.0
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="Portable.BouncyCastle" Version="1.8.6.7" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Portable.BouncyCastle" Version="1.9.0" />
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.2.12" Condition="'$(TargetFramework)' == 'uap10.0'" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" Condition="'$(TargetFramework)' == 'net461'" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />


### PR DESCRIPTION
Fixes an issue where `auto_expand_chaining` is returned from Instagram as a `null` value.

Also updates depends.